### PR TITLE
Correctly process log line that does not contain location.

### DIFF
--- a/src/Lurker/Events/TradeEvent.cs
+++ b/src/Lurker/Events/TradeEvent.cs
@@ -52,6 +52,10 @@ namespace Lurker.Events
             {
                 this.Location = this.ParseLocation(textAfterItemName.Substring(locationMarkerIndex));
             }
+            else
+            {
+                this.Location = new Location();
+            }
 
             // Price
             if (priceMarkerIndex != -1)


### PR DESCRIPTION
Some whispers do not contain the location of the item. For instance when found on bulk trade. If the location of an item could not be determined, use a generic location instead.

Without this line, whenever you receive a trade request generated via bulk trade website, Poe-Lurker will crash as location was `null`.