### PR TITLE
[Improvement] Parsing of incoming trade messages using a regular expression.

### DIFF
--- a/Lurker.sln
+++ b/Lurker.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Lurker", "src\Lurker\Lurker
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Lurker.UI", "src\Lurker.UI\Lurker.UI.csproj", "{F2FBBB7D-D7D9-4C01-A5A8-A3692DA521EE}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "tests", "tests\tests.csproj", "{3C93E505-EA40-4EBC-A649-BE866C92B9B2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,10 @@ Global
 		{F2FBBB7D-D7D9-4C01-A5A8-A3692DA521EE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F2FBBB7D-D7D9-4C01-A5A8-A3692DA521EE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F2FBBB7D-D7D9-4C01-A5A8-A3692DA521EE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3C93E505-EA40-4EBC-A649-BE866C92B9B2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3C93E505-EA40-4EBC-A649-BE866C92B9B2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3C93E505-EA40-4EBC-A649-BE866C92B9B2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3C93E505-EA40-4EBC-A649-BE866C92B9B2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Lurker.UI/ViewModels/OfferViewModel.cs
+++ b/src/Lurker.UI/ViewModels/OfferViewModel.cs
@@ -238,7 +238,7 @@ namespace Lurker.UI.ViewModels
         /// <returns>The item name to be placed in tab search.</returns>
         public string BuildSearchItemName()
         {
-            return this._tradeEvent.BuildSearchItemName();
+            return this._tradeEvent.ItemName;
         }
 
         /// <summary>

--- a/src/Lurker/Models/Location.cs
+++ b/src/Lurker/Models/Location.cs
@@ -4,6 +4,9 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System;
+using System.Text.RegularExpressions;
+
 namespace Lurker.Models
 {
     public class Location
@@ -35,6 +38,26 @@ namespace Lurker.Models
         public override string ToString()
         {
             return $"Tab: {this.StashTabName}, Left {this.Left}, Top {this.Top}";
+        }
+
+        /// <summary>
+        /// Factory method that creates a location of an item from the given log line.
+        /// </summary>
+        /// <param name="logLine">The log line.</param>
+        /// <returns>The location of the requested item.</returns>
+        public static Location FromLogLine(string logLine)
+        {
+            Match match = Regex.Match(logLine, @"(?:\(stash (?:tab )*\""(?<tab>.*)\""; (?:position: )*left (?<left>[0-9])+, top (?<top>[0-9]+)\))");
+            if (match.Success)
+            {
+                return new Location()
+                {
+                    StashTabName = match.Groups["tab"].Value,
+                    Left = Convert.ToInt32(match.Groups["left"].Value),
+                    Top = Convert.ToInt32(match.Groups["top"].Value)
+                };
+            }
+            return new Location();
         }
 
         #endregion

--- a/src/Lurker/Models/Price.cs
+++ b/src/Lurker/Models/Price.cs
@@ -4,12 +4,20 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using Lurker.Items;
 using Lurker.Items.Models;
+using System.Globalization;
+using System.Text.RegularExpressions;
 
 namespace Lurker.Models
 {
     public class Price
     {
+        #region Fields
+
+        private static readonly CurrencyTypeParser currencyTypeParser = new CurrencyTypeParser();
+
+        #endregion
         #region Properties
 
         /// <summary>
@@ -32,6 +40,25 @@ namespace Lurker.Models
         public override string ToString()
         {
             return $"{this.NumberOfCurrencies} {this.CurrencyType}";
+        }
+
+        /// <summary>
+        /// Factory method that creates Price from the given log line.
+        /// </summary>
+        /// <param name="logLine">A line of log.</param>
+        /// <returns>Returns an instance of Price.</returns>
+        public static Price FromLogLine(string logLine)
+        {
+            Match match = Regex.Match(logLine, @"(?:listed for|for my) (?<price>[0-9\.]+) (?<currency>.*?) in");
+            if (match.Success)
+            {
+                return new Price()
+                {
+                    CurrencyType = currencyTypeParser.Parse(match.Groups["currency"].Value),
+                    NumberOfCurrencies = double.Parse(match.Groups["price"].Value, CultureInfo.InvariantCulture)
+                };
+            }
+            return new Price();
         }
 
         #endregion

--- a/tests/Events/TradeEventTests.cs
+++ b/tests/Events/TradeEventTests.cs
@@ -1,0 +1,109 @@
+﻿using Lurker.Events;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+
+namespace tests.Events
+{
+    [TestClass]
+    public class TradeEventTests
+    {
+        [TestMethod]
+        public void TryParseReturnsNullWhenLogLineIsNotWhisperTest()
+        {
+            List<string> log_lines = new List<string>
+            {
+                @"2020/02/07 09:42:45 ***** LOG FILE OPENING *****",
+                @"2020/02/07 09:42:45 600605633 1c7 [INFO Client 8] Send patching protocol version 5",
+                @"2020/02/07 09:42:45 600605677 23d [INFO Client 8] Web root: http://patch.poecdn.com/patch/3.9.2.6/",
+                @"2020/02/07 09:42:45 600605677 23e [INFO Client 8] Backup Web root: http://patchcdn.pathofexile.com/3.9.2.6/",
+                @"2020/02/07 09:42:45 600605677 249 [INFO Client 8] Requesting root contents 1",
+                @"2020/02/07 09:42:45 600605695 273 [INFO Client 8] Got file list for "" 0",
+                @"2020/02/07 09:44:22 600702850 20c [DEBUG Client 67] CreateSwapChain: SetFullScreenState 0"
+            };
+
+            foreach (string log_line in log_lines)
+            {
+                Assert.IsNull(TradeEvent.TryParse(log_line));
+            }
+        }
+
+        [TestMethod]
+        public void TryParseReturnsCorrectObjectWhenLogLineIsParseableTest()
+        {
+            List<string> log_lines = new List<string>
+            {
+                @"2020/02/09 23:29:54 361878531 ac9[INFO Client 19460] @From test_name_1: wtb Fire and Ice listed for 5 Chaos Orb in Metamorph(stash ""~price 5 chaos""; left 1, top 12)",
+                @"2020/02/09 23:04:49 360373843 ac9[INFO Client 19460] @From < Some Guild > Test Name: Hi, I would like to buy your Morbid Portent Ghastly Eye Jewel listed for 15 chaos in Metamorph(stash tab ""~b/o 15 chaos""; position: left 6, top 23)",
+                @"2020/01/17 21:48:39 160281265 ac9[INFO Client 4788] @From 안녕 세상: I'd like to buy your 1 Hall of Grandmasters Promenade Map (T16) for my 10 Silver Coin in Metamorph.",
+                @"2020/01/17 21:48:39 160281265 ac9[INFO Client 4788] @From Привет_мир: Hi, I'd like to buy your 2 exalted for my 360 chaos in Metamorph. how does 3c sound?",
+                @"2020/01/31 00:19:26 257478656 ac9[INFO Client 16028] @From абвв: Hi, I would like to buy your Mao Kun Shore Map(T4) listed for 5 chaos in Metamorph(stash tab ""~price 5 chaos""; position: left 2, top 12) how about 3c ?",
+                @"2020/01/31 00:19:26 257478656 ac9 [INFO Client 16028] @From Ram_zDPS: Hi, I would like to buy your Miracle Pelt Sharkskin Tunic listed for 1.1 exa in Metamorph (stash tab ""~b/o 1.1 exa""; position: left 7, top 22)1ex ?",
+                @"2020/01/31 00:19:26 257478656 ac9[INFO Client 16028] @From Luke_Flystalker: Hi, I would like to buy your level 20 23% Spirit Offering listed for 1.1 exa in Metamorph(stash tab ""tekoop""; position: left 3, top 11)"
+            };
+
+            var tevt = TradeEvent.TryParse(log_lines[0]);
+            Assert.IsNotNull(tevt);
+            Assert.AreEqual(tevt.ItemName, "Fire and Ice");
+            Assert.AreEqual(tevt.Price.CurrencyType, Lurker.Items.Models.CurrencyType.Chaos);
+            Assert.AreEqual(tevt.Price.NumberOfCurrencies, 5);
+            Assert.AreEqual(tevt.Location.StashTabName, "~price 5 chaos");
+            Assert.AreEqual(tevt.Location.Left, 1);
+            Assert.AreEqual(tevt.Location.Top, 12);
+            Assert.AreEqual(tevt.Note, "");
+            tevt = TradeEvent.TryParse(log_lines[1]);
+            Assert.IsNotNull(tevt);
+            Assert.AreEqual(tevt.ItemName, "Morbid Portent Ghastly Eye Jewel");
+            Assert.AreEqual(tevt.Price.CurrencyType, Lurker.Items.Models.CurrencyType.Chaos);
+            Assert.AreEqual(tevt.Price.NumberOfCurrencies, 15);
+            Assert.AreEqual(tevt.Location.StashTabName, "~b/o 15 chaos");
+            Assert.AreEqual(tevt.Location.Left, 6);
+            Assert.AreEqual(tevt.Location.Top, 23);
+            Assert.AreEqual(tevt.Note, "");
+            tevt = TradeEvent.TryParse(log_lines[2]);
+            Assert.IsNotNull(tevt);
+            Assert.AreEqual(tevt.ItemName, "Hall of Grandmasters Promenade Map (T16)");
+            Assert.AreEqual(tevt.Price.CurrencyType, Lurker.Items.Models.CurrencyType.Unknown);
+            Assert.AreEqual(tevt.Price.NumberOfCurrencies, 10);
+            Assert.IsNull(tevt.Location.StashTabName);
+            Assert.AreEqual(tevt.Location.Left, 0);
+            Assert.AreEqual(tevt.Location.Top, 0);
+            Assert.AreEqual(tevt.Note, "");
+            tevt = TradeEvent.TryParse(log_lines[3]);
+            Assert.IsNotNull(tevt);
+            Assert.AreEqual(tevt.ItemName, "exalted");
+            Assert.AreEqual(tevt.Price.CurrencyType, Lurker.Items.Models.CurrencyType.Chaos);
+            Assert.AreEqual(tevt.Price.NumberOfCurrencies, 360);
+            Assert.IsNull(tevt.Location.StashTabName);
+            Assert.AreEqual(tevt.Location.Left, 0);
+            Assert.AreEqual(tevt.Location.Top, 0);
+            Assert.AreEqual(tevt.Note, "how does 3c sound?");
+            tevt = TradeEvent.TryParse(log_lines[4]);
+            Assert.IsNotNull(tevt);
+            Assert.AreEqual(tevt.ItemName, "Mao Kun Shore Map(T4)");
+            Assert.AreEqual(tevt.Price.CurrencyType, Lurker.Items.Models.CurrencyType.Chaos);
+            Assert.AreEqual(tevt.Price.NumberOfCurrencies, 5);
+            Assert.AreEqual(tevt.Location.StashTabName, "~price 5 chaos");
+            Assert.AreEqual(tevt.Location.Left, 2);
+            Assert.AreEqual(tevt.Location.Top, 12);
+            Assert.AreEqual(tevt.Note, "how about 3c ?");
+            tevt = TradeEvent.TryParse(log_lines[5]);
+            Assert.IsNotNull(tevt);
+            Assert.AreEqual(tevt.ItemName, "Miracle Pelt Sharkskin Tunic");
+            Assert.AreEqual(tevt.Price.CurrencyType, Lurker.Items.Models.CurrencyType.Exalted);
+            Assert.AreEqual(tevt.Price.NumberOfCurrencies, 1.1);
+            Assert.AreEqual(tevt.Location.StashTabName, "~b/o 1.1 exa");
+            Assert.AreEqual(tevt.Location.Left, 7);
+            Assert.AreEqual(tevt.Location.Top, 22);
+            Assert.AreEqual(tevt.Note, "1ex ?");
+            tevt = TradeEvent.TryParse(log_lines[6]);
+            Assert.IsNotNull(tevt);
+            Assert.AreEqual(tevt.ItemName, "Spirit Offering");
+            Assert.AreEqual(tevt.Price.CurrencyType, Lurker.Items.Models.CurrencyType.Exalted);
+            Assert.AreEqual(tevt.Price.NumberOfCurrencies, 1.1);
+            Assert.AreEqual(tevt.Location.StashTabName, "tekoop");
+            Assert.AreEqual(tevt.Location.Left, 3);
+            Assert.AreEqual(tevt.Location.Top, 11);
+            Assert.AreEqual(tevt.Note, "");
+        }
+    }
+}

--- a/tests/Models/LocationTests.cs
+++ b/tests/Models/LocationTests.cs
@@ -1,0 +1,62 @@
+﻿using Lurker.Models;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace tests.Models
+{
+    [TestClass]
+    public class LocationTests
+    {
+        [TestMethod]
+        public void FromLogLineReturnsCorrectObjectWhenLocationIsPresentTest()
+        {
+            string logLine = @"2020/01/31 00:19:26 257478656 ac9 [INFO Client 16028] @From абвв: " +
+                @"Hi, I would like to buy your Mao Kun Shore Map (T4) listed for 5 chaos in Metamorph " +
+                @"(stash tab ""~price 5 chaos""; position: left 2, top 12)";
+
+            var loc = Location.FromLogLine(logLine);
+
+            Assert.AreEqual("~price 5 chaos", loc.StashTabName);
+            Assert.AreEqual(2, loc.Left);
+            Assert.AreEqual(12, loc.Top);
+        }
+
+        [TestMethod]
+        public void FromLogLineReturnsCorrectObjectWhenLocationIsMissingPositionTest()
+        {
+            string logLine = @"2020/02/09 23:29:54 361878531 ac9[INFO Client 19460] @From test_name_1: " +
+                @"wtb Fire and Ice listed for 5 Chaos Orb in Metamorph(stash ""~price 5 chaos""; left 1, top 12)";
+
+            var loc = Location.FromLogLine(logLine);
+
+            Assert.AreEqual("~price 5 chaos", loc.StashTabName);
+            Assert.AreEqual(1, loc.Left);
+            Assert.AreEqual(12, loc.Top);
+        }
+
+        [TestMethod]
+        public void FromLogLineReturnsEmptyObjectWhenLocationIsMissingTest()
+        {
+            string logLine = @"2020/01/17 21:48:39 160281265 ac9[INFO Client 4788] @From 안녕 세상: " +
+                @"I'd like to buy your 1 Hall of Grandmasters Promenade Map (T16) for my 10 Silver Coin in Metamorph.";
+
+            var loc = Location.FromLogLine(logLine);
+
+            Assert.IsNull(loc.StashTabName);
+            Assert.AreEqual(0, loc.Left);
+            Assert.AreEqual(0, loc.Top);
+        }
+
+        [TestMethod]
+        public void FromLogLineReturnsEmptyObjectWhenLocationIsMalformedTest()
+        {
+            string logLine = @"2020/01/17 21:48:39 160281265 ac9[INFO Client 4788] @From 안녕 세상: " +
+                @"wtb Fire and Ice listed for 5 Chaos Orb in Metamorph(stash ""~price 5 chaos""; left a, top b)";
+
+            var loc = Location.FromLogLine(logLine);
+
+            Assert.IsNull(loc.StashTabName);
+            Assert.AreEqual(0, loc.Left);
+            Assert.AreEqual(0, loc.Top);
+        }
+    }
+}

--- a/tests/Models/PriceTests.cs
+++ b/tests/Models/PriceTests.cs
@@ -1,0 +1,48 @@
+﻿using Lurker.Models;
+using Lurker.Items.Models;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace tests.Models
+{
+    [TestClass]
+    public class PriceTests
+    {
+        [TestMethod]
+        public void FromLogLineReturnsObjectWhenPriceIsPresentTest()
+        {
+            string logLine = @"2020/01/17 21:48:39 160281265 ac9[INFO Client 4788] @From Привет_мир: " +
+                @"Hi, I'd like to buy your 2 exalted for my 360 chaos in Metamorph.";
+
+            var price = Price.FromLogLine(logLine);
+
+            Assert.AreEqual(CurrencyType.Chaos, price.CurrencyType);
+            Assert.AreEqual(360, price.NumberOfCurrencies);
+        }
+
+        [TestMethod]
+        public void FromLogLineReturnsCorrectAmountOfCurrencyTest()
+        {
+            string logLine = @"2020/01/31 00:19:26 257478656 ac9 [INFO Client 16028] @From Ram_zDPS: " + 
+                @"Hi, I would like to buy your Miracle Pelt Sharkskin Tunic listed for 1.1 exa in " + 
+                @"Metamorph (stash tab ""~b / o 1.1 exa""; position: left 7, top 22) 1ex ?";
+
+            var price = Price.FromLogLine(logLine);
+
+            Assert.AreEqual(CurrencyType.Exalted, price.CurrencyType);
+            Assert.AreEqual(1.1, price.NumberOfCurrencies);
+        }
+
+        [TestMethod]
+        public void FromLogLineReturnsEmptyObjectWhenLogLineIsMalformed()
+        {
+            string logLine = @"2020/01/31 00:19:26 257478656 ac9 [INFO Client 16028] @From Ram_zDPS: " + 
+                @"Hi, I would like to buy your Miracle Pelt Sharkskin Tunic listed for exa in Metamorph " +
+                @"(stash tab ""~b/o 1.1 exa""; position: left 7, top 22) 1ex ?";
+
+            var price = Price.FromLogLine(logLine);
+
+            Assert.AreEqual(CurrencyType.Unknown, price.CurrencyType);
+            Assert.AreEqual(0.0, price.NumberOfCurrencies);
+        }
+    }
+}

--- a/tests/Properties/AssemblyInfo.cs
+++ b/tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,20 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("tests")]
+[assembly: AssemblyCopyright("Copyright ©  2020")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+[assembly: ComVisible(false)]
+
+[assembly: Guid("3c93e505-ea40-4ebc-a649-be866c92b9b2")]
+
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/tests/packages.config
+++ b/tests/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="MSTest.TestAdapter" version="1.3.2" targetFramework="net472" />
+  <package id="MSTest.TestFramework" version="1.3.2" targetFramework="net472" />
+</packages>

--- a/tests/tests.csproj
+++ b/tests/tests.csproj
@@ -1,0 +1,77 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props')" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{3C93E505-EA40-4EBC-A649-BE866C92B9B2}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>tests</RootNamespace>
+    <AssemblyName>tests</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Lurker.Items, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" />
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.1.3.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.1.3.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Events\TradeEventTests.cs" />
+    <Compile Include="Models\PriceTests.cs" />
+    <Compile Include="Models\LocationTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\src\Lurker\Lurker.csproj">
+      <Project>{4e21f049-82d6-4853-8c59-b0addf3a4383}</Project>
+      <Name>Lurker</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets'))" />
+  </Target>
+  <Import Project="..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets')" />
+</Project>


### PR DESCRIPTION
Currently, the parsing of incoming messages is done by scanning the text for appropriate anchors and then extracting substrings and converting them. This approach is quite cumbersome, as with each change to the text produced by trade website the level of complicity is increased noticeably. In addition, the current solution has no control of the input and is not easily extendible.

The following PR aims at easing some of the issues. With the use of regular expressions, not only we can easily match appropriate messages, but we can also easily control the input values. 

I have tried to split the regular expressions to multiple classes (by creating factory methods for both `Location` and `Price` classes that extract needed values directly from the logline) and make the general regular expression as robust as possible while not sacrificing the readability of the expression.

In this PR I have included several UnitTests for the newly implemented features to make sure the features are working as intended.

In addition to the above improvements, this PR fixes a bug where the following logline was not processed correctly and caused the application to crash:

```
2020/02/09 23:29:54 361878531 ac9 [INFO Client 19460] @From PoubelleDeTable: wtb Fire and Ice listed for 5 Chaos Orb in Metamorph (stash "~price 5 chaos"; left 1, top 12)
```

Lurker failed because it expected `position` string to be placed before the actual position of the item, but for `poeapp.com` messages this information is missing.

Please, go over the code and let me know if there's something a miss and you want me to correct.

With best regards,
tamaroth