### PR TITLE
Use invariant culture when parsing from string to double.

### DIFF
--- a/src/Lurker/Events/TradeEvent.cs
+++ b/src/Lurker/Events/TradeEvent.cs
@@ -10,6 +10,7 @@ namespace Lurker.Events
     using Lurker.Models;
     using Lurker.Parser;
     using System;
+    using System.Globalization;
     using System.Linq;
     using System.Text.RegularExpressions;
 
@@ -165,7 +166,7 @@ namespace Lurker.Events
 
             return new Price()
             {
-                NumberOfCurrencies = double.Parse(values[0]),
+                NumberOfCurrencies = double.Parse(values[0], CultureInfo.InvariantCulture),
                 CurrencyType = CurrencyTypeParser.Parse(currencyTypeValue),
             };
         }


### PR DESCRIPTION
The known trade websites (poe.trade, pathofexile.com/trade, poeapp.com) are all using a full-stop as a decimal point. However, `PoE-Lurker` is using system-specific culture for converting from string. As a result, a string `1.1` is converted to 11 rather to its expected value when it's run on a system that has different culture info.

To properly parse the string, we should use `InvariantCulture` as it is stable and constant across framework versions, operating systems, and cannot be modified by users.