### PR TITLE
Include time since the offer was received in the tooltip.

### DIFF
--- a/src/Lurker.UI/ViewModels/OfferViewModel.cs
+++ b/src/Lurker.UI/ViewModels/OfferViewModel.cs
@@ -82,6 +82,22 @@ namespace Lurker.UI.ViewModels
         public Price Price => this._tradeEvent.Price;
 
         /// <summary>
+        /// Gets or sets the time span since the offer was received.
+        /// </summary>
+        public TimeSpan Elapsed
+        {
+            get
+            {
+                return this._tradeEvent.Elapsed;
+            }
+
+            set
+            {
+                this._tradeEvent.Elapsed = value;
+                this.NotifyOfPropertyChange();
+            }
+        }
+        /// <summary>
         /// Gets or sets a value indicating whether this instance is invite sended.
         /// </summary>
         public OfferStatus Status
@@ -188,6 +204,15 @@ namespace Lurker.UI.ViewModels
             this._skipMainAction = true;
             this.Waiting = true;
             this.Whisper(this._settingsService.BusyMessage);
+        }
+
+        /// <summary>
+        /// Updates the time span since the offer was received.
+        /// </summary>
+        public void UpdateElapsed()
+        {
+            var elp = DateTime.Now - this._tradeEvent.Date;
+            this.Elapsed = new TimeSpan(elp.Hours, elp.Minutes, elp.Seconds);
         }
 
         /// <summary>

--- a/src/Lurker.UI/ViewModels/OfferViewModel.cs
+++ b/src/Lurker.UI/ViewModels/OfferViewModel.cs
@@ -211,8 +211,8 @@ namespace Lurker.UI.ViewModels
         /// </summary>
         public void UpdateElapsed()
         {
-            var elp = DateTime.Now - this._tradeEvent.Date;
-            this.Elapsed = new TimeSpan(elp.Hours, elp.Minutes, elp.Seconds);
+            var elapsed = DateTime.Now - this._tradeEvent.Date;
+            this.Elapsed = new TimeSpan(elapsed.Hours, elapsed.Minutes, elapsed.Seconds);
         }
 
         /// <summary>

--- a/src/Lurker.UI/Views/OfferView.xaml
+++ b/src/Lurker.UI/Views/OfferView.xaml
@@ -8,6 +8,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:cal="http://www.caliburnproject.org"
              xmlns:local="clr-namespace:Lurker.UI"
+             xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
              mc:Ignorable="d" 
              d:DesignHeight="65" d:DesignWidth="65">
     <Border BorderThickness="2" CornerRadius="4">
@@ -25,6 +26,11 @@
             ToolTipService.InitialShowDelay="{Binding ToolTipDelay}"
             MinWidth="{Binding ActualHeight, RelativeSource={RelativeSource Self}}"
             MaxWidth="{Binding ActualHeight, RelativeSource={RelativeSource Self}}">
+            <i:Interaction.Triggers>
+                <i:EventTrigger EventName="MouseEnter">
+                    <cal:ActionMessage MethodName="UpdateElapsed"/>
+                </i:EventTrigger>
+            </i:Interaction.Triggers>
             <Button.Template>
                 <ControlTemplate TargetType="{x:Type Button}">
                     <Border CornerRadius="4">
@@ -258,6 +264,7 @@
                                                 <RowDefinition></RowDefinition>
                                                 <RowDefinition></RowDefinition>
                                                 <RowDefinition></RowDefinition>
+                                                <RowDefinition></RowDefinition>
                                             </Grid.RowDefinitions>
                                             <TextBlock Grid.Row="0" Text="{Binding PlayerName}"/>
                                             <TextBlock Grid.Row="1" Text="{Binding ItemName}"/>
@@ -272,6 +279,7 @@
                                                     </Style>
                                                 </TextBlock.Style>
                                             </TextBlock>
+                                            <TextBlock Grid.Row="3" Text="{Binding Elapsed}"/>
                                         </Grid>
                                     </ToolTip>
                                 </Setter.Value>

--- a/src/Lurker/Events/PoeEvent.cs
+++ b/src/Lurker/Events/PoeEvent.cs
@@ -42,6 +42,11 @@ namespace Lurker.Events
         /// </summary>
         public DateTime Date { get; private set; }
 
+        /// <summary>
+        /// Gets or sets the time span from the event till now.
+        /// </summary>
+        public TimeSpan Elapsed { get; set; }
+
         protected string Informations { get; private set; }
 
         /// <summary>


### PR DESCRIPTION
When hovering over an offer, it will now display information how long
ago the offer was received. It becomes handy if you leave game running
and leave the desk and return to several offers. It's good information
whether the offer was received 20 seconds ago or 5 minutes.

I was not able to get `Caliburn.Micro` actions working. It never reacted to `MouseEnter` event. Using some SE posts I devised an alternative that is using Microsoft library.

If you do not wish to use this library, I would appreciate if you showed me how to get the actions to work.